### PR TITLE
Add virtio-video QUERY_CONTROL cmd and support for encoder ID

### DIFF
--- a/hw/display/vhost-user-video.c
+++ b/hw/display/vhost-user-video.c
@@ -276,8 +276,16 @@ static void vhost_user_video_device_realize(DeviceState *dev, Error **errp)
         return;
     }
 
-    /* TODO Implement VIDEO_ENC, currently only support VIDEO_DEC */
-    virtio_init(vdev, VIRTIO_ID_VIDEO_DECODER, sizeof(struct virtio_video_config));
+    if (video->conf.type == NULL || !strcmp(video->conf.type, "decoder")) {
+        virtio_init(vdev, VIRTIO_ID_VIDEO_DECODER,
+                    sizeof(struct virtio_video_config));
+    } else if (!strcmp(video->conf.type, "encoder")) {
+        virtio_init(vdev, VIRTIO_ID_VIDEO_ENCODER,
+                    sizeof(struct virtio_video_config));
+    } else {
+        error_report("invalid type received: %s", video->conf.type);
+        goto vhost_dev_init_failed;
+    }
 
     /* one command queue and one event queue */
     video->vhost_dev.nvqs = 2;
@@ -347,6 +355,7 @@ static const VMStateDescription vhost_user_video_vmstate = {
 
 static Property vhost_user_video_properties[] = {
     DEFINE_PROP_CHR("chardev", VHostUserVIDEO, conf.chardev),
+    DEFINE_PROP_STRING("dev_type", VHostUserVIDEO, conf.type),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/include/hw/virtio/vhost-user-video.h
+++ b/include/hw/virtio/vhost-user-video.h
@@ -22,6 +22,7 @@
 
 typedef struct {
     CharBackend chardev;
+    char *type;
     struct virtio_video_config config;
 } VHostUserVIDEOConf;
 

--- a/tools/vhost-user-video/README.md
+++ b/tools/vhost-user-video/README.md
@@ -50,7 +50,7 @@ vhost-user-video --socket-path=/tmp/video.sock --v4l2-device=/dev/video3
 
 # Qemu command for virtio-video device
 
--device vhost-user-video-pci,chardev=video,id=video
+-device vhost-user-video-pci,chardev=video,dev_type=decoder,id=video
 -chardev socket,path=/tmp//video.sock,id=video
 
 # Example v4l2-ctl decode command

--- a/tools/vhost-user-video/v4l2_backend.c
+++ b/tools/vhost-user-video/v4l2_backend.c
@@ -1335,6 +1335,28 @@ int v4l2_video_get_format(int fd, enum v4l2_buf_type type,
     return 0;
 }
 
+int v4l2_video_query_control(int fd, uint32_t control, int32_t *value)
+{
+    int ret = 0;
+    struct v4l2_queryctrl ctrl;
+
+    g_debug("%s:%d", __func__, __LINE__);
+
+    ctrl.id = control;
+
+    ret = ioctl(fd, VIDIOC_QUERYCTRL, &ctrl);
+    if (ret < 0) {
+        g_printerr("Unable to query control: %s (%d).\n", g_strerror(errno),
+               errno);
+        return ret;
+    }
+
+    *value = ctrl.type;
+    g_debug("%s: ctrl=0x%x type=0x%x", __func__, control, *value);
+
+    return ret;
+}
+
 int v4l2_video_get_control(int fd , uint32_t control, int32_t *value)
 {
     int ret = 0;

--- a/tools/vhost-user-video/v4l2_backend.h
+++ b/tools/vhost-user-video/v4l2_backend.h
@@ -43,6 +43,7 @@ int v4l2_video_get_format(int fd, enum v4l2_buf_type type,
 int v4l2_video_set_format(int fd, enum v4l2_buf_type type,
                           struct virtio_video_params *p);
 
+int v4l2_video_query_control(int fd, uint32_t control, int32_t *value);
 int v4l2_video_get_control(int fd, uint32_t control, int32_t *value);
 
 int v4l2_queue_buffer(int fd, enum v4l2_buf_type type,

--- a/tools/vhost-user-video/virtio_video_helpers.c
+++ b/tools/vhost-user-video/virtio_video_helpers.c
@@ -177,13 +177,17 @@ uint32_t virtio_video_v4l2_format_to_virtio(uint32_t v4l2_format)
  * e.g. https://elixir.bootlin.com/linux/v5.12.1/source/
  * include/uapi/linux/v4l2-controls.h#L669
  */
-static struct virtio_video_convert_table control_table[] = {
-    { VIRTIO_VIDEO_CONTROL_BITRATE, V4L2_CID_MPEG_VIDEO_BITRATE },
-    { VIRTIO_VIDEO_CONTROL_PROFILE, V4L2_CID_MPEG_VIDEO_H264_PROFILE },
-    { VIRTIO_VIDEO_CONTROL_LEVEL, V4L2_CID_MPEG_VIDEO_H264_LEVEL },
-    { VIRTIO_VIDEO_CONTROL_FORCE_KEYFRAME,
-      V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME },
-    { 0 },
+static struct virtio_video_convert_table control_table[] = {                                                                                                                                                                                                                                                                 
+    { VIRTIO_VIDEO_CONTROL_BITRATE, V4L2_CID_MPEG_VIDEO_BITRATE },                                                                                                                                                                                                                                                           
+    { VIRTIO_VIDEO_CONTROL_BITRATE_PEAK, V4L2_CID_MPEG_VIDEO_BITRATE_PEAK },                                                                                                                                                                                                                                                 
+    { VIRTIO_VIDEO_CONTROL_BITRATE_MODE, V4L2_CID_MPEG_VIDEO_BITRATE_MODE },                                                                                                                                                                                                                                                 
+    { VIRTIO_VIDEO_CONTROL_PROFILE, V4L2_CID_MPEG_VIDEO_H264_PROFILE },                                                                                                                                                                                                                                                      
+    { VIRTIO_VIDEO_CONTROL_LEVEL, V4L2_CID_MPEG_VIDEO_H264_LEVEL },                                                                                                                                                                                                                                                          
+    { VIRTIO_VIDEO_CONTROL_FORCE_KEYFRAME,                                                                                                                                                                                                                                                                                   
+            V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME },                                                                                                                                                                                                                                                                           
+    { VIRTIO_VIDEO_CONTROL_PREPEND_SPSPPS_TO_IDR,                                                                                                                                                                                                                                                                            
+            V4L2_CID_MPEG_VIDEO_PREPEND_SPSPPS_TO_IDR },                                                                                                                                                                                                                                                                     
+    { 0 },                                                                                                                                                                                                                                                                                                                   
 };
 
 uint32_t virtio_video_control_to_v4l2(uint32_t control)


### PR DESCRIPTION
Although the encoding process is not fully supported yet, for completeness' sake
is good to have support for all commands in the patch. `QUERY_CONTROL` is
a command used during the negotiation part for encoding devices.
After this patch, the last command to be implemented will be
`VIRTIO_VIDEO_CMD_SET_CONTROL`.

The patch includes a small rework of the virtio_init process, to be able
to support both `enconding` and `decoding` devices with their respective
IDs. To achieve this, we introduce a `dev_type` option for the command line,
which allows selecting which type of device we are passing to qemu.