### PR TITLE
Add support for v4l2_memory_dmabuf

### DIFF
--- a/tools/vhost-user-video/meson.build
+++ b/tools/vhost-user-video/meson.build
@@ -1,5 +1,5 @@
 executable('vhost-user-video', files(
-  'main.c', 'v4l2_backend.c', 'virtio_video_helpers.c'),
+  'main.c', 'v4l2_backend.c', 'virtio_video_helpers.c', 'virtio_video_udmabuf.c'),
   dependencies: [qemuutil, glib, gio, vhost_user],
   install: true,
   install_dir: get_option('libexecdir'))

--- a/tools/vhost-user-video/v4l2_backend.h
+++ b/tools/vhost-user-video/v4l2_backend.h
@@ -15,8 +15,6 @@
 #include "standard-headers/linux/virtio_video.h"
 #include "virtio_video_helpers.h"
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
-
 #define MAX_CAPS_LEN 4096
 #define MAX_FMT_DESCS 64
 
@@ -32,8 +30,13 @@ void v4l2_backend_free(struct v4l2_device *dev);
 
 GByteArray *create_query_cap_resp(struct virtio_video_query_capability *qcmd,
                             GList **fmt_l, GByteArray *querycapresp);
-enum v4l2_buf_type get_v4l2_buf_type (enum virtio_video_queue_type queue_type,
-                                      bool has_mplane);
+enum v4l2_buf_type get_v4l2_buf_type(enum virtio_video_queue_type queue_type,
+                                     bool has_mplane);
+enum v4l2_memory get_v4l2_memory(enum virtio_video_mem_type mem_type);
+enum virtio_video_mem_type
+get_queue_mem_type(struct stream *s,
+                   enum virtio_video_queue_type queue_type);
+
 
 void v4l2_set_device_type(struct v4l2_device *dev, enum v4l2_buf_type type,
                           struct v4l2_fmtdesc *fmt_desc);
@@ -46,12 +49,15 @@ int v4l2_video_set_format(int fd, enum v4l2_buf_type type,
 int v4l2_video_query_control(int fd, uint32_t control, int32_t *value);
 int v4l2_video_get_control(int fd, uint32_t control, int32_t *value);
 
-int v4l2_queue_buffer(int fd, enum v4l2_buf_type type,
+int v4l2_queue_buffer(enum v4l2_buf_type type,
+                      enum v4l2_memory memory,
                       struct virtio_video_resource_queue *qcmd,
                       struct resource *res, struct stream *s,
-                      struct v4l2_device *dev);
+                      struct v4l2_device *dev,
+                      struct vuvbm_device *bm_dev);
 
 int v4l2_dequeue_buffer(int fd, enum v4l2_buf_type type,
+                        enum v4l2_memory memory,
                         struct stream *s);
 
 int v4l2_dequeue_event(struct v4l2_device *dev);
@@ -60,8 +66,9 @@ int v4l2_set_pixel_format(int fd, enum v4l2_buf_type buf_type,
                           uint32_t pixelformat);
 int v4l2_release_buffers(int fd, enum v4l2_buf_type type);
 int v4l2_resource_create(struct stream *s, enum v4l2_buf_type type,
-                         enum virtio_video_mem_type mem_type,
+                         enum v4l2_memory memory,
                          struct resource *res);
+int v4l2_reqbuf(int fd, enum v4l2_buf_type type, enum v4l2_memory memory, int *count);
 int v4l2_subscribe_event(struct stream *s,
                          uint32_t event_type, uint32_t id);
 
@@ -93,7 +100,7 @@ int v4l2_streamoff(enum v4l2_buf_type type, struct stream *s);
 void v4l2_print_event(const struct v4l2_event *ev);
 int v4l2_open(const gchar *devname);
 int v4l2_close(int fd);
-int v4l2_free_buffers(int fd, enum v4l2_buf_type type);
+int v4l2_free_buffers(int fd, enum v4l2_buf_type type, enum v4l2_memory memory);
 void convert_to_timeval(uint64_t timestamp, struct timeval *t);
 int v4l2_issue_cmd(int fd,  uint32_t cmd, uint32_t flags);
 

--- a/tools/vhost-user-video/virtio_video_helpers.h
+++ b/tools/vhost-user-video/virtio_video_helpers.h
@@ -19,10 +19,29 @@
 #include <linux/videodev2.h>
 #include "libvhost-user-glib.h"
 #include "libvhost-user.h"
+#include "qemu/uuid.h"
+#include "qemu/queue.h"
 
 /*
  * Structure to track internal state of VIDEO Device
  */
+
+struct resource;
+struct VuVideoDMABuf;
+
+struct vuvbm_device {
+    bool opened;
+    int fd;
+
+    bool (*alloc_bm)(struct VuVideoDMABuf *buf);
+    void (*free_bm)(struct VuVideoDMABuf *buf);
+    int (*get_fd)(struct VuVideoDMABuf *buf);
+    bool (*map_bm)(struct VuVideoDMABuf *buf);
+    void (*unmap_bm)(struct VuVideoDMABuf *buf);
+    void (*device_destroy)(struct vuvbm_device *dev);
+
+    GHashTable *resource_uuids;
+};
 
 typedef struct VuVideo {
     VugDev dev;
@@ -30,6 +49,7 @@ typedef struct VuVideo {
     GMainLoop *loop;
     struct v4l2_device *v4l2_dev;
     GList *streams;
+    struct vuvbm_device *bm_dev;
 } VuVideo;
 
 struct v4l2_device {
@@ -54,10 +74,18 @@ struct vu_video_ctrl_command {
 };
 
 
+typedef struct VuVideoDMABuf {
+    struct vuvbm_device *dev;
+    int memfd;
+    int dmafd;
+
+    void *start;
+    size_t length;
+} VuVideoDMABuf;
+
 /*
  * Structure to track internal state of a Stream
  */
-
 struct stream {
     struct virtio_video_stream_create vio_stream;
     uint32_t stream_id;
@@ -87,11 +115,13 @@ struct stream {
 
 struct resource {
     uint32_t stream_id;
+    QemuUUID uuid;
     struct virtio_video_resource_create vio_resource;
     struct virtio_video_resource_queue vio_res_q;
     struct iovec *iov;
     uint32_t iov_count;
     uint32_t v4l2_index;
+    struct VuVideoDMABuf *buf;
     enum v4l2_buf_type type;
     struct vu_video_ctrl_command *vio_q_cmd;
     bool queued;

--- a/tools/vhost-user-video/virtio_video_udmabuf.c
+++ b/tools/vhost-user-video/virtio_video_udmabuf.c
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Virtio Video Device
+ *
+ * Copyright Red Hat, Inc. 2023
+ *
+ * Authors:
+ *     Albert Esteve <aesteve@redhat.com>
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2 or later.
+ * See the COPYING file in the top-level directory.
+ */
+
+#include "qemu/osdep.h"
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include "linux/udmabuf.h"
+
+#include "vuvideo.h"
+
+static size_t
+udmabuf_get_size(struct VuVideoDMABuf *buf)
+{
+    return ROUND_UP(buf->length, qemu_real_host_page_size());
+}
+
+static bool
+udmabuf_alloc_bm(struct VuVideoDMABuf *buf)
+{
+    int ret;
+
+    buf->memfd = memfd_create("udmabuf-video-bm", MFD_ALLOW_SEALING);
+    if (buf->memfd < 0) {
+        g_printerr("%s: memfd_create failed.", __func__);
+        return false;
+    }
+
+    ret = ftruncate(buf->memfd, udmabuf_get_size(buf));
+    if (ret < 0) {
+        g_printerr("%s: ftruncate failed.", __func__);
+        close(buf->memfd);
+        return false;
+    }
+
+    ret = fcntl(buf->memfd, F_ADD_SEALS, F_SEAL_SHRINK);
+    if (ret < 0) {
+        g_printerr("%s: fcntl failed.", __func__);
+        close(buf->memfd);
+        return false;
+    }
+
+    return true;
+}
+
+static void
+udmabuf_free_bm(struct VuVideoDMABuf *buf)
+{
+    close(buf->memfd);
+}
+
+static bool
+udmabuf_map_bm(struct VuVideoDMABuf *buf)
+{
+    g_debug("Map the buffer memory.");
+    buf->start = mmap(NULL, udmabuf_get_size(buf),
+                      PROT_READ | PROT_WRITE, MAP_SHARED, buf->memfd, 0);
+    if (buf->start == MAP_FAILED) {
+        return false;
+    }
+
+    return true;
+}
+
+static void
+udmabuf_unmap_bm(struct VuVideoDMABuf *buf)
+{
+    g_debug("Unmap the buffer memory.");
+    munmap(buf->start, udmabuf_get_size(buf));
+}
+
+static int
+udmabuf_get_fd(struct VuVideoDMABuf *buf)
+{
+    if (buf->dmafd > 0) {
+        return buf->dmafd;
+    }
+
+    struct udmabuf_create create = {
+        .memfd = buf->memfd,
+        .offset = 0,
+        .size = udmabuf_get_size(buf),
+    };
+
+    buf->dmafd = ioctl(buf->dev->fd, UDMABUF_CREATE, &create);
+    if (buf->dmafd < 0) {
+        g_printerr("%s: UDMABUF_CREATE failed.", __func__);
+    }
+
+    return buf->dmafd;
+}
+
+static void
+udmabuf_device_destroy(struct vuvbm_device *dev)
+{
+    close(dev->fd);
+}
+
+static bool
+vuvbm_buffer_map(struct VuVideoDMABuf *buf)
+{
+    struct vuvbm_device *dev = buf->dev;
+
+    return dev->map_bm(buf);
+}
+
+bool vuvbm_buffer_create(struct vuvbm_device *dev, struct VuVideoDMABuf *buffer, uint32_t len)
+{
+    g_debug("Creating buffer length(%d)", len);
+    buffer->dev = dev;
+    buffer->length = len;
+    if (!dev->alloc_bm(buffer)) {
+        g_warning("alloc_bm failed");
+        return false;
+    }
+
+    if (!vuvbm_buffer_map(buffer)) {
+        g_warning("map_bm failed");
+        goto err;
+    }
+
+    return true;
+
+err:
+    buffer->dev->free_bm(buffer);
+    return false;
+}
+
+void vuvbm_init_device(struct vuvbm_device *dev) {
+    if (!dev->opened && g_file_test("/dev/udmabuf", G_FILE_TEST_EXISTS)) {
+        dev->fd = open("/dev/udmabuf", O_RDWR);
+        if (dev->fd >= 0) {
+            g_debug("Using experimental udmabuf backend");
+            dev->alloc_bm = udmabuf_alloc_bm;
+            dev->free_bm = udmabuf_free_bm;
+            dev->get_fd = udmabuf_get_fd;
+            dev->map_bm = udmabuf_map_bm;
+            dev->unmap_bm = udmabuf_unmap_bm;
+            dev->device_destroy = udmabuf_device_destroy;
+            dev->resource_uuids = g_hash_table_new_full(NULL, NULL, NULL, g_free);
+            dev->opened = true;
+        }
+    }
+    g_debug("Using udmabuf backend");
+}
+
+struct VuVideoDMABuf *vuvbm_lookup(struct vuvbm_device *dev, QemuUUID uuid)
+{
+    g_debug("Lookup for buffer uuid(%s)", qemu_uuid_unparse_strdup(&uuid));
+    return g_hash_table_lookup(dev->resource_uuids, &uuid);
+}
+
+void vuvbm_buffer_destroy(struct VuVideoDMABuf *buffer)
+{
+    struct vuvbm_device *dev = buffer->dev;
+
+    dev->unmap_bm(buffer);
+    dev->free_bm(buffer);  
+}
+
+void vuvbm_device_destroy(struct vuvbm_device *dev)
+{
+    if (!dev->opened) {
+        return;
+    }
+
+    dev->device_destroy(dev);
+}

--- a/tools/vhost-user-video/vuvideo.h
+++ b/tools/vhost-user-video/vuvideo.h
@@ -16,7 +16,6 @@
 
 #include "virtio_video_helpers.h"
 #include "v4l2_backend.h"
-#include "vuvideo.h"
 
 size_t video_iov_size(const struct iovec *iov, const unsigned int iov_cnt);
 
@@ -39,5 +38,14 @@ void remove_all_resources(struct stream *s, uint32_t queue_type);
 
 void handle_queue_clear_cmd(struct VuVideo *v,
                            struct vu_video_ctrl_command *vio_cmd);
+
+/* virtio_video_udmabuf.c */
+bool vuvbm_buffer_create(struct vuvbm_device *dev,
+                         struct VuVideoDMABuf *buffer,
+                         uint32_t len);
+void vuvbm_init_device(struct vuvbm_device *dev);
+struct VuVideoDMABuf *vuvbm_lookup(struct vuvbm_device *dev, QemuUUID uuid);
+void vuvbm_buffer_destroy(struct VuVideoDMABuf *buffer);
+void vuvbm_device_destroy(struct vuvbm_device *dev);
 
 #endif


### PR DESCRIPTION
Support VIRTIO_VIDEO_MEM_TYPE_VIRTIO_OBJECT feature,
by importing DMA buffers using the v4l2 API.

In this patch, we do not import the buffer from
any other virtio device, but just create a DMA
buffer through udmabuf, and import it.

However, in preparation for the case where we
actually share buffers between different devices, we
store the UUID and keep buffers associated to them
in a hash table.

Signed-off-by: Albert Esteve <aesteve@redhat.com>