### PR TITLE
vhost-user-video: consolidate reqbuf

### DIFF
--- a/tools/vhost-user-video/v4l2_backend.c
+++ b/tools/vhost-user-video/v4l2_backend.c
@@ -1112,6 +1112,16 @@ int v4l2_queue_buffer(enum v4l2_buf_type type,
         }
     }
 
+    if (V4L2_TYPE_IS_OUTPUT(type)) {
+        if (video_is_mplane(type)) {
+            for (int i = 0; i < vbuf.length; i++) {
+                vbuf.m.planes[i].bytesused = vbuf.m.planes[i].length;
+            }
+        } else {
+            vbuf.bytesused = vbuf.length;
+        }
+    }
+
     ret = ioctl(fd, VIDIOC_QBUF, &vbuf);
     if (ret < 0) {
         qcmd->hdr.type = VIRTIO_VIDEO_RESP_ERR_INVALID_PARAMETER;

--- a/tools/vhost-user-video/v4l2_backend.h
+++ b/tools/vhost-user-video/v4l2_backend.h
@@ -65,9 +65,7 @@ int v4l2_dequeue_event(struct v4l2_device *dev);
 int v4l2_set_pixel_format(int fd, enum v4l2_buf_type buf_type,
                           uint32_t pixelformat);
 int v4l2_release_buffers(int fd, enum v4l2_buf_type type);
-int v4l2_resource_create(struct stream *s, enum v4l2_buf_type type,
-                         enum v4l2_memory memory,
-                         struct resource *res);
+int v4l2_resource_create(struct stream *s, uint32_t queue_type, uint32_t queue_len);
 int v4l2_reqbuf(int fd, enum v4l2_buf_type type, enum v4l2_memory memory, int *count);
 int v4l2_subscribe_event(struct stream *s,
                          uint32_t event_type, uint32_t id);


### PR DESCRIPTION
Instead of sending single VIDIOC_REQBUF per
RESOURCE_CREATE command, wait until the first
RESOURCE_QUEUE and send a signel VIDIOC_REQBUF
that initiates as many buffers as resources
we will need, in a single call.

This avoids errors when the buffer count returned
by the driver differs from the resources requested,
which breaks the buffer index logic.

Signed-off-by: Albert Esteve <aesteve@redhat.com>